### PR TITLE
fix: parenthese impossible dans un slug

### DIFF
--- a/projects/2025-01-25-potentiels(c)olaire/index.md
+++ b/projects/2025-01-25-potentiels(c)olaire/index.md
@@ -1,5 +1,5 @@
 ---
-slug: potentiels(c)olaire
+slug: potentielscolaire
 title: "Potentiel s(c)olaire"
 header_image_url: img/projects/potentiel-scolaire.png
 tags: [Saison 13]

--- a/src/pages/saison13/index.md
+++ b/src/pages/saison13/index.md
@@ -60,7 +60,7 @@ L’approche OD&IS aide à favoriser l’accueil et la mobilité des personnes e
 
 👉 Si vous voulez contribuer à ce projet, rejoignez Boris et Nassima dans le canal [#13_odis](https://data-for-good.slack.com/archives/C08AF157HK2)
 
-### [⛺ Projet 6 : Potentiel S(c)olaire) - Greenpeace](/projects/potentiels(c)olaire)
+### [⛺ Projet 6 : Potentiel S(c)olaire) - Greenpeace](/projects/potentielscolaire)
 
 Dans le cadre d'une campagne plus large sur les établissements scolaires français, Greenpeace souhaiterait trouver des chiffres fiables et clairs sur le potentiel photovoltaïque des bâtiments publics afin d'inciter les chefs d'établissements ou politiques à prendre des mesures. Le but est de construire une base de données contenant chaque école et son potentiel solaire, puis de l’exploiter dans un produit sous forme de carte.
 


### PR DESCRIPTION
Sur la page listant les projets de la saison 13, le lien vers le projet potentiel s(c)olaire mène à une page 404.
[https://dataforgood.fr/projects/tags/saison-13](Saison 13)

Les parenthèses non échapées ne sont pas gérées dans les url. Il faut donc supprimer les parenthèses dans le slug associé à ce projet.